### PR TITLE
Feature/7 add file doc block

### DIFF
--- a/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsComponent.java
+++ b/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsComponent.java
@@ -3,6 +3,7 @@ package com.turbinekreuzberg.plugins.settings;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.FormBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,6 +19,7 @@ public class AppSettingsComponent {
     private final JBCheckBox omsNavigationFeatureActiveCheckbox = new JBCheckBox("State machine navigation");
     private final JBCheckBox twigGotoHandlingFeatureActiveCheckbox = new JBCheckBox("Twig goto-handling");
     private final JBCheckBox transferObjectGotoHandlingFeatureActiveCheckbox = new JBCheckBox("Transfer object goto-handling");
+    private final JBTextArea fileDocBlockText = new JBTextArea();
 
     public AppSettingsComponent() {
         myMainPanel = FormBuilder.createFormBuilder()
@@ -34,6 +36,12 @@ public class AppSettingsComponent {
                 .addVerticalGap(10)
                 .addLabeledComponent(new JBLabel("PYZ directory (default is '/src/Pyz/')"), pyzDirectoryText, 1, false)
                 .addLabeledComponent(new JBLabel("PYZ namespace (default is 'Pyz')"), pyzNamespaceText, 1, false)
+                .addVerticalGap(10)
+                .addSeparator()
+                .addVerticalGap(10)
+                .addLabeledComponent(new JBLabel("File doc block for generated classes"), fileDocBlockText, 1, true)
+                .addVerticalGap(10)
+                .addSeparator()
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -110,5 +118,13 @@ public class AppSettingsComponent {
 
     public void setTransferObjectGotoHandlingFeatureActive(boolean newStatus) {
         transferObjectGotoHandlingFeatureActiveCheckbox.setSelected(newStatus);
+    }
+
+    public String getFileDocBlockText() {
+        return fileDocBlockText.getText();
+    }
+
+    public void setFileDocBlockText(String newText) {
+        fileDocBlockText.setText(newText);
     }
 }

--- a/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsConfigurable.java
+++ b/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsConfigurable.java
@@ -30,7 +30,8 @@ public class AppSettingsConfigurable implements Configurable {
     @Override
     public boolean isModified() {
         AppSettingsState settings = AppSettingsState.getInstance();
-        boolean modified = !mySettingsComponent.getPyzDirectoryText().equals(settings.pyzDirectory);
+        boolean modified = !mySettingsComponent.getFileDocBlockText().equals(settings.fileDocBlockText);
+        modified |= !mySettingsComponent.getPyzDirectoryText().equals(settings.pyzDirectory);
         modified |= !mySettingsComponent.getPyzNamespaceText().equals(settings.pyzNamespace);
         modified |= mySettingsComponent.getExtendInPyzFeatureActive() != settings.extendInPyzFeatureActive;
         modified |= mySettingsComponent.getViewOnGithubFeatureActive() != settings.viewOnGithubFeatureActive;
@@ -44,6 +45,7 @@ public class AppSettingsConfigurable implements Configurable {
     @Override
     public void apply() {
         AppSettingsState settings = AppSettingsState.getInstance();
+        settings.fileDocBlockText = mySettingsComponent.getFileDocBlockText();
         settings.pyzDirectory = mySettingsComponent.getPyzDirectoryText();
         settings.pyzNamespace = mySettingsComponent.getPyzNamespaceText();
         settings.extendInPyzFeatureActive = mySettingsComponent.getExtendInPyzFeatureActive();
@@ -57,6 +59,7 @@ public class AppSettingsConfigurable implements Configurable {
     @Override
     public void reset() {
         AppSettingsState settings = AppSettingsState.getInstance();
+        mySettingsComponent.setFileDocBlockText(settings.fileDocBlockText);
         mySettingsComponent.setPyzDirectoryText(settings.pyzDirectory);
         mySettingsComponent.setPyzNamespaceText(settings.pyzNamespace);
         mySettingsComponent.setExtendInPyzFeatureActive(settings.extendInPyzFeatureActive);

--- a/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsState.java
+++ b/src/main/java/com/turbinekreuzberg/plugins/settings/AppSettingsState.java
@@ -22,6 +22,7 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
     public boolean omsNavigationFeatureActive = true;
     public boolean twigGotoHandlingFeatureActive = true;
     public boolean transferObjectGotoHandlingFeatureActive = true;
+    public String fileDocBlockText;
 
     public static AppSettingsState getInstance() {
         return ApplicationManager.getApplication().getService(AppSettingsState.class);

--- a/src/main/java/com/turbinekreuzberg/plugins/utils/PhpContentCreator.java
+++ b/src/main/java/com/turbinekreuzberg/plugins/utils/PhpContentCreator.java
@@ -28,7 +28,7 @@ public class PhpContentCreator {
 
         if (!AppSettingsState.getInstance().fileDocBlockText.isBlank()) {
             contentWithClassName = contentWithClassName.replace(
-                "{{fileDocBlock}}", AppSettingsState.getInstance().fileDocBlockText
+                "{{fileDocBlock}}", AppSettingsState.getInstance().fileDocBlockText.trim()
             );
         }
 

--- a/src/main/java/com/turbinekreuzberg/plugins/utils/PhpContentCreator.java
+++ b/src/main/java/com/turbinekreuzberg/plugins/utils/PhpContentCreator.java
@@ -26,6 +26,12 @@ public class PhpContentCreator {
         contentWithClassName = contentWithClassName.replace("{{type}}", getType(file));
         contentWithClassName = contentWithClassName.replace("{{sprykerNamespace}}", sprykerNamespace);
 
+        if (!AppSettingsState.getInstance().fileDocBlockText.isBlank()) {
+            contentWithClassName = contentWithClassName.replace(
+                "{{fileDocBlock}}", AppSettingsState.getInstance().fileDocBlockText
+            );
+        }
+
         return contentWithClassName.replace("{{namespace}}", AppSettingsState.getInstance().pyzNamespace + "\\" + namespace);
     }
 

--- a/src/main/resources/templates/phpClass.txt
+++ b/src/main/resources/templates/phpClass.txt
@@ -1,5 +1,7 @@
 <?php
 
+{{fileDocBlock}}
+
 namespace {{namespace}};
 
 use {{sprykerNamespace}}\{{className}} as Spryker{{className}};


### PR DESCRIPTION
Hi

This pull request adds a new configurable field (fileDocBlockText) to the configuration which is then put into each new generated class (placeholder: fileDocBlock).

Be aware: The TextArea in the configuration window has no border around it (at least in my IDE). I didn't figure out how to fix this. I placed separators around it to make it at least a little more visible.
